### PR TITLE
Better handle config file errors

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -29,11 +29,20 @@ let romiConfig: RomiConfiguration;
 
 try {
     serviceConfig = new ServiceConfiguration(program as ProgramArguments);
-    romiConfig = new RomiConfiguration(program as ProgramArguments);
 }
 catch (err) {
     console.log(err.message);
     process.exit();
+}
+
+try {
+    romiConfig = new RomiConfiguration(program as ProgramArguments);
+}
+catch (err) {
+    romiConfig = new RomiConfiguration();
+    console.log("[CONFIG] Error loading romi configuration")
+    console.log(err.message);
+    console.log("[CONFIG] Falling back to defaults");
 }
 
 const I2C_BUS_NUM: number = 1;

--- a/src/romi-config.ts
+++ b/src/romi-config.ts
@@ -9,13 +9,13 @@ export interface RomiConfigJson {
 export default class RomiConfiguration {
     private _extIOConfig: IPinConfiguration[] = [];
 
-    constructor(programArgs: ProgramArguments) {
+    constructor(programArgs?: ProgramArguments) {
         // Pre-load the external IO configuration
         DEFAULT_IO_CONFIGURATION.forEach(val => this._extIOConfig.push(Object.assign({}, val)));
 
         let isConfigError: boolean = false;
 
-        if (programArgs.config !== undefined) {
+        if (programArgs && programArgs.config !== undefined) {
             try {
                 const romiConfig: RomiConfigJson = jsonfile.readFileSync(programArgs.config);
 

--- a/src/romi-robot.ts
+++ b/src/romi-robot.ts
@@ -101,13 +101,16 @@ export default class WPILibWSRomiRobot extends WPILibWSRobotBase {
                 return this._readByte(RomiDataBuffer.firmwareIdent.offset)
                 .then(fwIdent => {
                     this._firmwareIdent = fwIdent;
-                    if (this._firmwareIdent !== FIRMWARE_IDENT) {
-                        console.log("[FIRMWARE] Firmware Identifier Mismatch!");
-                    }
                 })
                 .catch(err => {
                     this._i2cErrorDetector.addErrorInstance();
                 });
+            })
+            .then(() => {
+                // Verify firmware
+                if (this._firmwareIdent !== FIRMWARE_IDENT) {
+                    console.log(`[FIRMWARE] Firmware Identifier Mismatch. Expected ${FIRMWARE_IDENT} but got ${this._firmwareIdent}`);
+                }
             })
             .then(() => {
                 // Initial set up of digital inputs (we set DIO 0 to input because it's a button)


### PR DESCRIPTION
This commit provides better support for errors in the romi configuration
file. In case of an error, we will now fall back to using defaults
instead of killing the service.