### PR TITLE
Fix encoder implementation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -105,20 +105,20 @@
       }
     },
     "@wpilib/node-wpilib-ws": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/@wpilib/node-wpilib-ws/-/node-wpilib-ws-0.0.5.tgz",
-      "integrity": "sha512-x+RGaXt+syJ1a4nE29COhr5VRAmR9JAd3RzTWqtvlfBVu4LjgyWQFe82H5InDErzIvoaI3vg2bFdeP3VFldHaw==",
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@wpilib/node-wpilib-ws/-/node-wpilib-ws-0.0.6.tgz",
+      "integrity": "sha512-2X/9/D/eqkjSj98e3xlK/6SQwTjiN/RVWo5y3fkVZ3FaXC5WI+Gl1+HWgzBJnjEPqqoeyfqKp+aMKDlMCsKZfw==",
       "requires": {
         "strict-event-emitter-types": "^2.0.0",
         "ws": "^7.3.1"
       }
     },
     "@wpilib/wpilib-ws-robot": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/@wpilib/wpilib-ws-robot/-/wpilib-ws-robot-0.0.8.tgz",
-      "integrity": "sha512-A2rOoIT4K4xx9EzE7cI3sC3tyoB+od3Ug5Un5GYNEcKvB+LOrksBtzJyPPYDNdUK9++QmkOPnXjItjpih/v7CQ==",
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/@wpilib/wpilib-ws-robot/-/wpilib-ws-robot-0.0.10.tgz",
+      "integrity": "sha512-81AiZnkD9nP9GVWhXOov6k0//jfVIbBuxgaGwRiLl16471eFDEzMNcwoKD8PbFNw2iXrk5u/6ApD8Jt1kqHVyg==",
       "requires": {
-        "@wpilib/node-wpilib-ws": "0.0.5"
+        "@wpilib/node-wpilib-ws": "0.0.6"
       }
     },
     "accepts": {
@@ -566,9 +566,9 @@
       "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw="
     },
     "ws": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.3.1.tgz",
-      "integrity": "sha512-D3RuNkynyHmEJIpD2qrgVkc9DQ23OrN/moAwZX4L8DfvszsJxpjQuUq3LMx6HoYji9fbIOBY18XWBsAux1ZZUA=="
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.0.tgz",
+      "integrity": "sha512-kyFwXuV/5ymf+IXhS6f0+eAFvydbaBW3zjpT6hUdAh/hbVjTIB5EHBGi0bPoCLSK2wcuz3BrEkB9LrYv1Nm4NQ=="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "homepage": "https://github.com/wpilibsuite/wpilib-ws-robot-romi#readme",
   "dependencies": {
-    "@wpilib/wpilib-ws-robot": "0.0.8",
+    "@wpilib/wpilib-ws-robot": "0.0.10",
     "commander": "^6.1.0",
     "express": "^4.17.1",
     "jsonfile": "^6.0.1",


### PR DESCRIPTION
This commit ensures that only appropriately registered encoders are
read (by checking the pin combinations supplied during encoder
registration). Additionally, this also implements encoder reversal

Resolves #39 