### PR TITLE
Fix promise rejection during robot init if not connected to romi

### DIFF
--- a/src/romi-robot.ts
+++ b/src/romi-robot.ts
@@ -141,6 +141,9 @@ export default class WPILibWSRomiRobot extends WPILibWSRobotBase {
                 })
                 .then(() => {
                     console.log("[ROMI] LSM6DS33 Initialized");
+                })
+                .catch(err => {
+                    console.log("[ROMI] Failed to initialize IMU");
                 });
             })
             .then(() => {
@@ -187,6 +190,9 @@ export default class WPILibWSRomiRobot extends WPILibWSRobotBase {
                         this._i2cErrorDetector.addErrorInstance();
                     });
                 }, 500);
+            })
+            .catch(err => {
+                console.log("[ROMI] Failed to initialize robot: ", err);
             });
     }
 


### PR DESCRIPTION
This commit allows service initialization to complete even if the raspberry pi is not connected to a Romi board. Previously, this would have caused a promise rejection to be thrown, interrupting the entire startup process.