### PR TITLE
bugfix: Actually reset gyro

### DIFF
--- a/src/gyro-calibration-util.ts
+++ b/src/gyro-calibration-util.ts
@@ -10,7 +10,7 @@ export interface CalibrationConfig {
     sampleIntervalMs?: number;
 }
 
-const DEFAULT_NUM_SAMPLES: number = 500;
+const DEFAULT_NUM_SAMPLES: number = 1500;
 const DEFAULT_SAMPLE_INTERVAL_MS: number = 20;
 
 export default class GyroCalibrationUtil {

--- a/src/lsm6.ts
+++ b/src/lsm6.ts
@@ -199,10 +199,6 @@ export default class LSM6 {
         this._gyroOffset = val;
     }
 
-    public resetGyro() {
-        this._gyro = { x: 0, y: 0, z: 0 };
-    }
-
     public async enableDefault(): Promise<void> {
         if (!this._isReady) {
             return;

--- a/src/romi-robot.ts
+++ b/src/romi-robot.ts
@@ -452,7 +452,7 @@ export default class WPILibWSRomiRobot extends WPILibWSRobotBase {
         if (this._numWsConnections === 0) {
             // Reset the gyro. This will ensure that the gyro will
             // read 0 (or close to it) as the robot program starts up
-            this._lsm6.resetGyro();
+            this._romiGyro.reset();
         }
 
         this._numWsConnections++;


### PR DESCRIPTION
There was a bug in the gyro reset logic that would zero out the
variables where the gyro rate was being stored, instead of zeroing out
the accumulator.

Additionally, bumping up the number of samples to collect for
calibration.