### PR TITLE
bugfix: Update IMU axes to follow NED + Right Hand Rule conventions

### DIFF
--- a/src/romi-accelerometer.ts
+++ b/src/romi-accelerometer.ts
@@ -32,7 +32,8 @@ export default class RomiAccelerometer extends RobotAccelerometer {
     }
 
     public update(): void {
-        this.accelX = this._lsm6.accelerationG.x;
+        // These follow NED conventions
+        this.accelX = -this._lsm6.accelerationG.x;
         this.accelY = this._lsm6.accelerationG.y;
         this.accelZ = this._lsm6.accelerationG.z;
     }

--- a/src/romi-gyro.ts
+++ b/src/romi-gyro.ts
@@ -25,16 +25,20 @@ export default class RomiGyro extends RobotGyro {
 
         const currGyroValues = this._lsm6.gyroDPS;
 
+        const gyroRateX = currGyroValues.x;
+        const gyroRateY = -currGyroValues.y;
+        const gyroRateZ = -currGyroValues.z;
+
         // Set the rate values
-        this.rateX = currGyroValues.x;
-        this.rateY = currGyroValues.y;
-        this.rateZ = currGyroValues.z;
+        this.rateX = gyroRateX
+        this.rateY = gyroRateY;
+        this.rateZ = gyroRateZ;
 
         // Calculate the angles
         const timeDiffInSeconds = (currUpdateTimeMs - this._lastUpdateTimeMs) / 1000;
-        this._angle.x = this._angle.x + (timeDiffInSeconds * currGyroValues.x);
-        this._angle.y = this._angle.y + (timeDiffInSeconds * currGyroValues.y);
-        this._angle.z = this._angle.z + (timeDiffInSeconds * currGyroValues.z);
+        this._angle.x = this._angle.x + (timeDiffInSeconds * gyroRateX);
+        this._angle.y = this._angle.y + (timeDiffInSeconds * gyroRateY);
+        this._angle.z = this._angle.z + (timeDiffInSeconds * gyroRateZ);
 
         // Set the angles
         this.angleX = this._angle.x;


### PR DESCRIPTION
This commit updates the Romi IMU axis values to follow the North-East-Down convention for axis directions, as well as the Right Hand Rule for rotation (i.e. clockwise rotation around the Z axis is positive)

See https://docs.wpilib.org/en/stable/docs/software/actuators/wpi-drive-classes.html#axis-conventions for more details

Resolves #81 