### PR TITLE
feature: Add DS IP Server

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -817,6 +817,12 @@
         "pretty-format": "^26.0.0"
       }
     },
+    "@types/jsbn": {
+      "version": "1.2.29",
+      "resolved": "https://registry.npmjs.org/@types/jsbn/-/jsbn-1.2.29.tgz",
+      "integrity": "sha512-2dVz9LTEGWVj9Ov9zaDnpvqHFV+W4bXtU0EUEGAzWfdRNO3dlUuosdHpENI6/oQW+Kejn0hAjk6P/czs9h/hvg==",
+      "dev": true
+    },
     "@types/jsonfile": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/@types/jsonfile/-/jsonfile-6.0.0.tgz",
@@ -900,20 +906,21 @@
       "dev": true
     },
     "@wpilib/node-wpilib-ws": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@wpilib/node-wpilib-ws/-/node-wpilib-ws-0.1.0.tgz",
-      "integrity": "sha512-J/uzdLq7MYk4mwa42Lv2f6OcXcMSKGnZNPc4CKQW1Ozbb2nnxfj171EOnI5FDdws6EPhhnYixD0+ehsdLOJtAA==",
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@wpilib/node-wpilib-ws/-/node-wpilib-ws-0.1.1.tgz",
+      "integrity": "sha512-qwhEhJD2Gj7RjqDOoyEClcwE94SA+era1ljoQ/L1P7WK8UYQy2sfjx6MSM2d0sFPCXeELSNUmgTqVd711ni61A==",
       "requires": {
+        "ip-address": "^7.1.0",
         "strict-event-emitter-types": "^2.0.0",
         "ws": "^7.3.1"
       }
     },
     "@wpilib/wpilib-ws-robot": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/@wpilib/wpilib-ws-robot/-/wpilib-ws-robot-0.1.2.tgz",
-      "integrity": "sha512-3wUWvlglTeC85bAoNGByKjSmlfhRiFxZGy9gQqzcRDuV6OsxLRgNUbJgcw+X56bNz3XnUUffIYZYhwWrmDKUUQ==",
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@wpilib/wpilib-ws-robot/-/wpilib-ws-robot-0.1.3.tgz",
+      "integrity": "sha512-Pxl5VA4MBvywIGHmtw9796H/bN7CQI3ynWL8FvuxLYnSR/3UZPHESGSQfitQrPcAEUjEeJ4v6suTwt13+2B0xQ==",
       "requires": {
-        "@wpilib/node-wpilib-ws": "0.1.0"
+        "@wpilib/node-wpilib-ws": "0.1.1"
       }
     },
     "abab": {
@@ -2403,6 +2410,27 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
       "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+    },
+    "ip-address": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-7.1.0.tgz",
+      "integrity": "sha512-V9pWC/VJf2lsXqP7IWJ+pe3P1/HCYGBMZrrnT62niLGjAfCbeiwXMUxaeHvnVlz19O27pvXP4azs+Pj/A0x+SQ==",
+      "requires": {
+        "jsbn": "1.1.0",
+        "sprintf-js": "1.1.2"
+      },
+      "dependencies": {
+        "jsbn": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-1.1.0.tgz",
+          "integrity": "sha1-sBMHyym2GKHtJux56RH4A8TaAEA="
+        },
+        "sprintf-js": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.2.tgz",
+          "integrity": "sha512-VE0SOVEHCk7Qc8ulkWw3ntAzXuqf7S2lvwQaDLRnUeIEaKNQJzV6BwmLKhOqT61aGhfUMrXeaBk+oDGCzvhcug=="
+        }
+      }
     },
     "ip-regex": {
       "version": "2.1.0",

--- a/package.json
+++ b/package.json
@@ -28,10 +28,11 @@
   },
   "homepage": "https://github.com/wpilibsuite/wpilib-ws-robot-romi#readme",
   "dependencies": {
-    "@wpilib/wpilib-ws-robot": "0.1.2",
+    "@wpilib/wpilib-ws-robot": "0.1.3",
     "commander": "^6.1.0",
     "cors": "^2.8.5",
     "express": "^4.17.1",
+    "ip-address": "^7.1.0",
     "jsonfile": "^6.0.1",
     "promise-queue": "^2.2.5"
   },
@@ -43,6 +44,7 @@
     "@types/express": "^4.17.9",
     "@types/i2c-bus": "^5.1.0",
     "@types/jest": "^26.0.20",
+    "@types/jsbn": "^1.2.29",
     "@types/jsonfile": "^6.0.0",
     "@types/node": "^14.6.0",
     "@types/promise-queue": "^2.2.0",

--- a/src/ds-interface/ds-ip-server.ts
+++ b/src/ds-interface/ds-ip-server.ts
@@ -1,0 +1,76 @@
+import { Server, Socket } from "net";
+import { Address4 } from "ip-address";
+
+const DS_IP_INTERFACE_PORT: number = 1742;
+
+export default class DSServer {
+    private _ipAddrString: string = "";
+    private _ipAddrNum: number = 0;
+
+    private _server: Server;
+
+    private _activeSockets: Socket[] = [];
+
+    public updateRobotCodeIpV4Addr(newIp: string | null): void {
+        if (newIp !== this._ipAddrString) {
+            if (newIp === null) {
+                this._ipAddrString = "";
+                this._ipAddrNum = 0;
+            }
+            else {
+                if (!Address4.isValid(newIp)) {
+                    console.log("[DS-INTERFACE] Invalid IP address provided");
+                    return;
+                }
+
+                this._ipAddrString = newIp;
+                const addr = new Address4(newIp);
+                const addrArray = addr.toArray();
+                const addrNum = (addrArray[0] << 24) |
+                                (addrArray[1] << 16) |
+                                (addrArray[2] << 8) |
+                                addrArray[3];
+                this._ipAddrNum = addrNum;
+            }
+
+            this._informAllClients();
+        }
+    }
+
+    public start() {
+        this._server = new Server((socket) => {
+            this._activeSockets.push(socket);
+            this._informClient(socket);
+
+            socket.once("close", (hadError) => {
+                for (let i = 0; i < this._activeSockets.length; i++) {
+                    if (this._activeSockets[i] === socket) {
+                        console.log("[DS-INTERFACE] Socket removed");
+                        this._activeSockets.splice(i, 1);
+                        break;
+                    }
+                }
+            });
+        });
+
+        this._server.listen(DS_IP_INTERFACE_PORT);
+    }
+
+    public stop() {
+        if (this._server && this._server.listening) {
+            console.log("[DS-INTERFACE] Server Closing");
+            this._server.close();
+            this._server = undefined;
+        }
+    }
+
+    private _informAllClients() {
+        this._activeSockets.forEach(socket => {
+            this._informClient(socket);
+        });
+    }
+
+    private _informClient(socket: Socket) {
+        socket.write(`{"robotIP":${this._ipAddrNum}}\n`);
+    }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,7 @@ import { FIRMWARE_IDENT } from "./romi-shmem-buffer";
 import RestInterface from "./rest-interface/rest-interface";
 import MockRomiImu from "./mocks/mock-imu";
 import GyroCalibrationUtil from "./gyro-calibration-util";
+import DSServer from "./ds-interface/ds-ip-server";
 
 let packageVersion: string = "0.0.0";
 
@@ -186,6 +187,17 @@ restInterface.addIMUStatusQuery("accel-reading", () => {
 
 restInterface.addIMUStatusQuery("gyro-offset", () => {
     return robot.getIMU().gyroOffset;
+});
+
+const dsServer: DSServer = new DSServer();
+dsServer.start();
+
+robot.on("wsConnection", (remoteConnectionInfo) => {
+    dsServer.updateRobotCodeIpV4Addr(remoteConnectionInfo.remoteAddrV4);
+});
+
+robot.on("wsNoConnections", () => {
+    dsServer.updateRobotCodeIpV4Addr(null);
 });
 
 endpoint.startP()

--- a/src/romi-robot.ts
+++ b/src/romi-robot.ts
@@ -451,7 +451,7 @@ export default class WPILibWSRomiRobot extends WPILibWSRobotBase {
     /**
      * Called when a new WebSocket connection occurs
      */
-    public onWSConnection(): void {
+    public onWSConnection(remoteAddrV4?: string): void {
         // If this is the first WS connection
         if (this._numWsConnections === 0) {
             // Reset the gyro. This will ensure that the gyro will
@@ -460,6 +460,10 @@ export default class WPILibWSRomiRobot extends WPILibWSRobotBase {
         }
 
         this._numWsConnections++;
+
+        this.emit("wsConnection", {
+            remoteAddrV4
+        });
     }
 
     /**
@@ -471,6 +475,7 @@ export default class WPILibWSRomiRobot extends WPILibWSRobotBase {
         // If this was our last disconnection, clear out all the state
         if (this._numWsConnections === 0) {
             this._resetToCleanState();
+            this.emit("wsNoConnections");
         }
     }
 


### PR DESCRIPTION
This PR adds an additional TCP server that broadcasts the current IP address of the NT server. 

Since the robot application is running on the development computer (and not the Romi Raspberry Pi), vision applications running on the Pi will not know how to connect to NT. The DS IP server on the Romi Raspberry Pi determines the IP address of the computer running robot code by using the remoteAddress information of incoming WebSocket connections. This IP address is then advertised by the DS IP server.

All this results in being able to load up a camera stream in SmartDashboard/Shuffleboard and view a connected Romi camera, out of the box.