### PR TITLE
feature: Use IMU FIFO

### DIFF
--- a/src/__examples__/lsm6-tester.ts
+++ b/src/__examples__/lsm6-tester.ts
@@ -1,0 +1,39 @@
+import LSM6 from "../robot/devices/core/lsm6/lsm6";
+import I2CPromisifiedBus from "../device-interfaces/i2c/i2c-connection";
+import { FIFOModeSelection, OutputDataRate } from "../robot/devices/core/lsm6/lsm6-settings";
+
+async function main() {
+    const I2C_BUS_NUM = 1;
+
+    let i2cBus: I2CPromisifiedBus;
+    try {
+        const HardwareI2C = require("../device-interfaces/i2c/hw-i2c").default;
+        i2cBus = new HardwareI2C(I2C_BUS_NUM);
+    }
+    catch (err) {
+        console.error("Could not load hardware I2C. Bailing out");
+        process.exit(1);
+    }
+
+    const lsm6 = new LSM6(i2cBus, 0x6B);
+
+    await lsm6.init();
+
+    lsm6.settings.accelFIFOEnabled = true;
+    lsm6.settings.gyroFIFOEnabled = true;
+    lsm6.settings.accelODR = OutputDataRate.ODR_104_HZ;
+    lsm6.settings.gyroODR = OutputDataRate.ODR_104_HZ;
+    lsm6.settings.fifoSampleRate = OutputDataRate.ODR_104_HZ;
+    lsm6.settings.fifoModeSelection = FIFOModeSelection.CONTINUOUS;
+
+    await lsm6.begin();
+    lsm6.fifoStart();
+
+    setInterval(() => {
+        const frames = lsm6.getNewFIFOData();
+        console.log(`NUMBER OF FRAMES: ${frames.length}`);
+    }, 50);
+}
+
+
+main();

--- a/src/__mocks__/mock-imu.ts
+++ b/src/__mocks__/mock-imu.ts
@@ -14,4 +14,11 @@ export default class MockRomiImu extends MockI2CDevice {
         return Promise.resolve();
     }
 
+    public sendByte(cmd: number): Promise<void> {
+        return Promise.resolve();
+    }
+
+    public receiveByte(): Promise<number> {
+        return Promise.resolve(0);
+    }
 }

--- a/src/__mocks__/mock-romi.ts
+++ b/src/__mocks__/mock-romi.ts
@@ -93,6 +93,28 @@ export default class MockRomiI2C extends MockI2CDevice {
         return Promise.reject("IO Error");
     }
 
+    public sendByte(cmd: number): Promise<void> {
+        if (this._isError) {
+            return Promise.reject("IO Error");
+        }
+
+        if (cmd < this._incomingBuffer.length) {
+            // TODO do something?
+            return Promise.resolve();
+        }
+
+        return Promise.reject("IO Error");
+    }
+
+    public receiveByte(): Promise<number> {
+        if (this._isError) {
+            return Promise.reject("IO Error");
+        }
+
+        // TODO Implement
+        return Promise.resolve(0);
+    }
+
     // Mock Romi functions
     public setFirmwareIdent(ident: number) {
         this._actualBuffer[RomiShmemBuffer.firmwareIdent.offset] = ident & 0xFF;

--- a/src/__tests__/device-interfaces/queued-i2c.ts
+++ b/src/__tests__/device-interfaces/queued-i2c.ts
@@ -81,6 +81,13 @@ class TestDevice extends MockI2CDevice {
         return Promise.resolve();
     }
 
+    public sendByte(cmd: number): Promise<void> {
+        return Promise.resolve();
+    }
+
+    public receiveByte(): Promise<number> {
+        return Promise.resolve(0);
+    }
 }
 
 describe("Queued I2C Bus", () => {

--- a/src/device-interfaces/i2c/hw-i2c.ts
+++ b/src/device-interfaces/i2c/hw-i2c.ts
@@ -77,6 +77,22 @@ export default class HardwareI2C extends I2CPromisifiedBus {
         });
     }
 
+    public sendByte(addr: number, cmd: number): Promise<void> {
+        this._logger.silly(`sendByte(addr=0x${addr.toString(16)}, cmd=0x${cmd.toString(16)})`);
+        return this._i2cBusP
+        .then(bus => {
+            return bus.sendByte(addr, cmd);
+        });
+    }
+
+    public receiveByte(addr: number): Promise<number> {
+        this._logger.silly(`receiveByte(addr=0x${addr.toString(16)})`);
+        return this._i2cBusP
+        .then(bus => {
+            return bus.receiveByte(addr);
+        });
+    }
+
     private _postWriteDelay(delayMs: number = 1): Promise<void> {
         return new Promise((resolve) => {
             setTimeout(() => {

--- a/src/device-interfaces/i2c/i2c-connection.ts
+++ b/src/device-interfaces/i2c/i2c-connection.ts
@@ -14,4 +14,7 @@ export default abstract class I2CPromisifiedBus {
     public abstract readWord(addr: number, cmd: number, romiMode?: boolean): Promise<number>;
     public abstract writeByte(addr: number, cmd: number, byte: number): Promise<void>;
     public abstract writeWord(addr: number, cmd: number, word: number): Promise<void>;
+
+    public abstract sendByte(addr: number, cmd: number): Promise<void>;
+    public abstract receiveByte(addr: number): Promise<number>;
 }

--- a/src/device-interfaces/i2c/mock-i2c-device.ts
+++ b/src/device-interfaces/i2c/mock-i2c-device.ts
@@ -13,4 +13,6 @@ export default abstract class MockI2CDevice {
     public abstract readWord(cmd: number): Promise<number>;
     public abstract writeByte(cmd: number, byte: number): Promise<void>;
     public abstract writeWord(cmd: number, word: number): Promise<void>;
+    public abstract sendByte(cmd: number): Promise<void>;
+    public abstract receiveByte(): Promise<number>;
 }

--- a/src/device-interfaces/i2c/mock-i2c.ts
+++ b/src/device-interfaces/i2c/mock-i2c.ts
@@ -7,7 +7,9 @@ export enum MockI2CBusEventType {
     READ_BYTE = "READ_BYTE",
     READ_WORD = "READ_WORD",
     WRITE_BYTE = "WRITE_BYTE",
-    WRITE_WORD = "WROTE_WORD",
+    WRITE_WORD = "WRITE_WORD",
+    SEND_BYTE = "SEND_BYTE",
+    RECEIVE_BYTE = "RECEIVE_BYTE",
     IO_ERROR = "IO_ERROR",
     BUS_CLOSE = "BUS_CLOSE"
 }
@@ -161,6 +163,46 @@ export default class MockI2C extends I2CPromisifiedBus {
             eventType: MockI2CBusEventType.IO_ERROR,
             address: addr,
             cmd,
+            errDescription: "No Device Associated With Address"
+        });
+        return Promise.reject(`[MOCK-I2C] IO Error - No device with address ${addr}`);
+    }
+
+    public sendByte(addr: number, cmd: number): Promise<void> {
+        this._logger.silly(`sendByte(addr=0x${addr.toString(16)}, cmd=0x${cmd.toString(16)})`);
+
+        if (this._devices.has(addr)) {
+            this._notifyListeners({
+                eventType: MockI2CBusEventType.SEND_BYTE,
+                address: addr,
+                cmd
+            });
+            return this._devices.get(addr).sendByte(cmd);
+        }
+        
+        this._notifyListeners({
+            eventType: MockI2CBusEventType.IO_ERROR,
+            address: addr,
+            cmd,
+            errDescription: "No Device Associated With Address"
+        });
+        return Promise.reject(`[MOCK-I2C] IO Error - No device with address ${addr}`);
+    }
+
+    public receiveByte(addr: number): Promise<number> {
+        this._logger.silly(`sendByte(addr=0x${addr.toString(16)})`);
+
+        if (this._devices.has(addr)) {
+            this._notifyListeners({
+                eventType: MockI2CBusEventType.SEND_BYTE,
+                address: addr
+            });
+            return this._devices.get(addr).receiveByte();
+        }
+        
+        this._notifyListeners({
+            eventType: MockI2CBusEventType.IO_ERROR,
+            address: addr,
             errDescription: "No Device Associated With Address"
         });
         return Promise.reject(`[MOCK-I2C] IO Error - No device with address ${addr}`);

--- a/src/index.ts
+++ b/src/index.ts
@@ -185,7 +185,7 @@ else {
 }
 
 // Set up the gyro calibration util
-const gyroCalibrationUtil: GyroCalibrationUtil = new GyroCalibrationUtil(robot.getIMU());
+const gyroCalibrationUtil: GyroCalibrationUtil = new GyroCalibrationUtil(robot);
 
 // Set up the REST interface
 const restInterface: RestInterface = new RestInterface();

--- a/src/robot/devices/core/lsm6/lsm6-settings.ts
+++ b/src/robot/devices/core/lsm6/lsm6-settings.ts
@@ -1,0 +1,59 @@
+export enum OutputDataRate {
+    ODR_DISABLED = "DISABLED",
+    ODR_12_5_HZ = "12.5Hz",
+    ODR_26_HZ = "26Hz",
+    ODR_52_HZ = "52Hz",
+    ODR_104_HZ = "104Hz",
+    ODR_208_HZ = "208Hz",
+    ODR_416_HZ = "416Hz",
+    ODR_833_HZ = "833Hz",
+    ODR_1_66_KHZ = "1.66KHz",
+    ODR_3_33_KHZ = "3.33KHz",
+    ODR_6_66_KHZ = "6.66KHz"
+}
+
+// Range scales for the accelerometer
+export enum AccelerometerScale {
+    SCALE_2G = "SCALE_2G",
+    SCALE_4G = "SCALE_4G",
+    SCALE_8G = "SCALE_8G",
+    SCALE_16G = "SCALE_16G"
+}
+
+// Range scales for the gyro
+export enum GyroScale {
+    SCALE_125_DPS = "SCALE_125_DPS",
+    SCALE_250_DPS = "SCALE_250_DPS",
+    SCALE_500_DPS = "SCALE_500_DPS",
+    SCALE_1000_DPS = "SCALE_1000_DPS",
+    SCALE_2000_DPS = "SCALE_2000_DPS"
+}
+
+export enum FIFOModeSelection {
+    BYPASS = "BYPASS",
+    FIFO = "FIFO",
+    CONTINUOUS_FIFO = "CONTINUOUS_FIFO",
+    BYPASS_CONTINUOUS = "BYPASS_CONTINUOUS",
+    CONTINUOUS = "CONTINUOUS"
+}
+
+export default class LSM6Settings {
+    // Gyro settings
+    public gyroEnabled: boolean = true;
+    public gyroRange: GyroScale = GyroScale.SCALE_1000_DPS;
+    public gyroODR: OutputDataRate = OutputDataRate.ODR_104_HZ;
+    public gyroFIFOEnabled: boolean = false;
+    public gyroFIFODecimation: number = 1;
+
+    // Accelerometer Settings
+    public accelEnabled: boolean = true;
+    public accelRange: AccelerometerScale = AccelerometerScale.SCALE_2G;
+    public accelODR: OutputDataRate = OutputDataRate.ODR_104_HZ;
+    public accelFIFOEnabled: boolean = false;
+    public accelFIFODecimation: number = 1;
+
+    // FIFO Control Data
+    public fifoThreshold: number = 0;
+    public fifoSampleRate: OutputDataRate = OutputDataRate.ODR_104_HZ;
+    public fifoModeSelection: FIFOModeSelection = FIFOModeSelection.BYPASS;
+}

--- a/src/robot/devices/core/lsm6/lsm6.ts
+++ b/src/robot/devices/core/lsm6/lsm6.ts
@@ -1,7 +1,8 @@
 import LogUtil from "../../../../utils/logging/log-util";
 import I2CPromisifiedBus from "../../../../device-interfaces/i2c/i2c-connection";
+import LSM6Settings, { AccelerometerScale, FIFOModeSelection, GyroScale, OutputDataRate } from "./lsm6-settings";
 
-// LSM6DS33 Datasheet: https://www.pololu.com/file/0J1087/LSM6DS33.pdf
+// LSM6DS33 Datasheet: https://www.st.com/resource/en/datasheet/lsm6ds33.pdf
 
 enum RegAddr {
     FUNC_CFG_ACCESS   = 0x01,
@@ -77,22 +78,74 @@ enum RegAddr {
 const DS33_WHO_ID = 0x69;
 const IF_INC_ENABLED = 0x04;
 
-// Range scales for the accelerometer
-export enum AccelerometerScale {
-    SCALE_2G = "SCALE_2G",
-    SCALE_4G = "SCALE_4G",
-    SCALE_8G = "SCALE_8G",
-    SCALE_16G = "SCALE_16G"
+enum CTRL3_C_OPTIONS {
+    BOOT = 1 << 7,
+    BDU = 1 << 6,
+    H_LACTIVE = 1 << 5,
+    PP_OD = 1 << 4,
+    SIM = 1 << 3,
+    IF_INC = 1 << 2,
+    BLE = 1 << 1,
+    SW_RESET = 1
 }
 
-// Range scales for the gyro
-export enum GyroScale {
-    SCALE_125_DPS = "SCALE_125_DPS",
-    SCALE_250_DPS = "SCALE_250_DPS",
-    SCALE_500_DPS = "SCALE_500_DPS",
-    SCALE_1000_DPS = "SCALE_1000_DPS",
-    SCALE_2000_DPS = "SCALE_2000_DPS"
+export interface FIFOFrame {
+    gyroX: number;
+    gyroY: number;
+    gyroZ: number;
+    accelX: number;
+    accelY: number;
+    accelZ: number;
 }
+
+// Used with FIFO_CTRL5
+const FIFO_ODR_BYTE: Map<OutputDataRate, number> = new Map<OutputDataRate, number>();
+FIFO_ODR_BYTE.set(OutputDataRate.ODR_DISABLED, 0x00);
+FIFO_ODR_BYTE.set(OutputDataRate.ODR_12_5_HZ, (0x1) << 3);
+FIFO_ODR_BYTE.set(OutputDataRate.ODR_26_HZ, (0x2) << 3);
+FIFO_ODR_BYTE.set(OutputDataRate.ODR_52_HZ, (0x3) << 3);
+FIFO_ODR_BYTE.set(OutputDataRate.ODR_104_HZ, (0x4) << 3);
+FIFO_ODR_BYTE.set(OutputDataRate.ODR_208_HZ, (0x5) << 3);
+FIFO_ODR_BYTE.set(OutputDataRate.ODR_416_HZ, (0x6) << 3);
+FIFO_ODR_BYTE.set(OutputDataRate.ODR_833_HZ, (0x7) << 3);
+FIFO_ODR_BYTE.set(OutputDataRate.ODR_1_66_KHZ, (0x8) << 3);
+FIFO_ODR_BYTE.set(OutputDataRate.ODR_3_33_KHZ, (0x9) << 3);
+FIFO_ODR_BYTE.set(OutputDataRate.ODR_6_66_KHZ, (0xA) << 3);
+
+// Used with CTRL1_XL
+const XL_ODR_BYTE: Map<OutputDataRate, number> = new Map<OutputDataRate, number>();
+XL_ODR_BYTE.set(OutputDataRate.ODR_DISABLED, 0x00);
+XL_ODR_BYTE.set(OutputDataRate.ODR_12_5_HZ, (0x1) << 4);
+XL_ODR_BYTE.set(OutputDataRate.ODR_26_HZ, (0x2) << 4);
+XL_ODR_BYTE.set(OutputDataRate.ODR_52_HZ, (0x3) << 4);
+XL_ODR_BYTE.set(OutputDataRate.ODR_104_HZ, (0x4) << 4);
+XL_ODR_BYTE.set(OutputDataRate.ODR_208_HZ, (0x5) << 4);
+XL_ODR_BYTE.set(OutputDataRate.ODR_416_HZ, (0x6) << 4);
+XL_ODR_BYTE.set(OutputDataRate.ODR_833_HZ, (0x7) << 4);
+XL_ODR_BYTE.set(OutputDataRate.ODR_1_66_KHZ, (0x8) << 4);
+XL_ODR_BYTE.set(OutputDataRate.ODR_3_33_KHZ, (0x9) << 4);
+XL_ODR_BYTE.set(OutputDataRate.ODR_6_66_KHZ, (0xA) << 4);
+
+// Used with CTRL2_G
+const G_ODR_BYTE: Map<OutputDataRate, number> = new Map<OutputDataRate, number>();
+G_ODR_BYTE.set(OutputDataRate.ODR_DISABLED, 0x00);
+G_ODR_BYTE.set(OutputDataRate.ODR_12_5_HZ, (0x1) << 4);
+G_ODR_BYTE.set(OutputDataRate.ODR_26_HZ, (0x2) << 4);
+G_ODR_BYTE.set(OutputDataRate.ODR_52_HZ, (0x3) << 4);
+G_ODR_BYTE.set(OutputDataRate.ODR_104_HZ, (0x4) << 4);
+G_ODR_BYTE.set(OutputDataRate.ODR_208_HZ, (0x5) << 4);
+G_ODR_BYTE.set(OutputDataRate.ODR_416_HZ, (0x6) << 4);
+G_ODR_BYTE.set(OutputDataRate.ODR_833_HZ, (0x7) << 4);
+G_ODR_BYTE.set(OutputDataRate.ODR_1_66_KHZ, (0x8) << 4);
+G_ODR_BYTE.set(OutputDataRate.ODR_3_33_KHZ, (0x8) << 4);
+G_ODR_BYTE.set(OutputDataRate.ODR_6_66_KHZ, (0x8) << 4);
+
+const FIFO_MODE_BYTE: Map<FIFOModeSelection, number> = new Map<FIFOModeSelection, number>();
+FIFO_MODE_BYTE.set(FIFOModeSelection.BYPASS, 0x0);
+FIFO_MODE_BYTE.set(FIFOModeSelection.FIFO, 0x1);
+FIFO_MODE_BYTE.set(FIFOModeSelection.CONTINUOUS_FIFO, 0x3);
+FIFO_MODE_BYTE.set(FIFOModeSelection.BYPASS_CONTINUOUS, 0x4);
+FIFO_MODE_BYTE.set(FIFOModeSelection.CONTINUOUS, 0x6);
 
 export interface Vector3 {
     x: number;
@@ -100,11 +153,26 @@ export interface Vector3 {
     z: number;
 }
 
+// Used with CTRL1_XL
+const XL_FS_BYTE: Map<AccelerometerScale, number> = new Map<AccelerometerScale, number>();
+XL_FS_BYTE.set(AccelerometerScale.SCALE_2G, 0x00);
+XL_FS_BYTE.set(AccelerometerScale.SCALE_4G, 0x08);
+XL_FS_BYTE.set(AccelerometerScale.SCALE_8G, 0x0C);
+XL_FS_BYTE.set(AccelerometerScale.SCALE_16G, 0x04);
+
 const ACCEL_SCALE_CTRL_BYTE: Map<AccelerometerScale, number> = new Map<AccelerometerScale, number>();
 ACCEL_SCALE_CTRL_BYTE.set(AccelerometerScale.SCALE_2G, 0x40);
 ACCEL_SCALE_CTRL_BYTE.set(AccelerometerScale.SCALE_4G, 0x48);
 ACCEL_SCALE_CTRL_BYTE.set(AccelerometerScale.SCALE_8G, 0x4C);
 ACCEL_SCALE_CTRL_BYTE.set(AccelerometerScale.SCALE_16G, 0x44);
+
+// Used with CTRL2_G
+const G_FS_BYTE: Map<GyroScale, number> = new Map<GyroScale, number>();
+G_FS_BYTE.set(GyroScale.SCALE_125_DPS, 0x02);
+G_FS_BYTE.set(GyroScale.SCALE_250_DPS, 0x00);
+G_FS_BYTE.set(GyroScale.SCALE_500_DPS, 0x04);
+G_FS_BYTE.set(GyroScale.SCALE_1000_DPS, 0x08);
+G_FS_BYTE.set(GyroScale.SCALE_2000_DPS, 0x0C);
 
 const GYRO_SCALE_CTRL_BYTE: Map<GyroScale, number> = new Map<GyroScale, number>();
 GYRO_SCALE_CTRL_BYTE.set(GyroScale.SCALE_125_DPS, 0x42);
@@ -133,6 +201,31 @@ export interface LSM6Config {
     gyroOffset?: Vector3;
 }
 
+function getFIFOPeriod(rate: OutputDataRate): number {
+    switch (rate) {
+        case OutputDataRate.ODR_12_5_HZ:
+            return 1 / 12.5;
+        case OutputDataRate.ODR_26_HZ:
+            return 1 / 26.0;
+        case OutputDataRate.ODR_52_HZ:
+            return 1 / 52.0;
+        case OutputDataRate.ODR_104_HZ:
+            return 1 / 104.0;
+        case OutputDataRate.ODR_208_HZ:
+            return 1 / 208.0;
+        case OutputDataRate.ODR_416_HZ:
+            return 1 / 416.0;
+        case OutputDataRate.ODR_833_HZ:
+            return 1 / 833.0;
+        case OutputDataRate.ODR_1_66_KHZ:
+            return 1 / 1660.0;
+        case OutputDataRate.ODR_3_33_KHZ:
+            return 1 / 3330.0;
+        case OutputDataRate.ODR_6_66_KHZ:
+            return 1 / 6660.0;
+    }
+}
+
 const logger = LogUtil.getLogger("IMU-ONBOARD");
 
 export default class LSM6 {
@@ -147,8 +240,10 @@ export default class LSM6 {
 
     private _isReady: boolean = false;
 
-    private _accelerometerScale: AccelerometerScale = AccelerometerScale.SCALE_2G;
-    private _gyroScale: GyroScale = GyroScale.SCALE_250_DPS;
+    private _settings: LSM6Settings = new LSM6Settings();
+
+    private _fifoRunning: boolean = false;
+    private _fifoBuffer: FIFOFrame[] = [];
 
     constructor(bus: I2CPromisifiedBus, address: number, config?: LSM6Config) {
         this._i2cAddress = address;
@@ -178,6 +273,10 @@ export default class LSM6 {
         });
     }
 
+    public get settings(): LSM6Settings {
+        return this._settings;
+    }
+
     public get accelerationG(): Vector3 {
         return this._accel;
     }
@@ -202,10 +301,82 @@ export default class LSM6 {
         this._gyroOffset = val;
     }
 
+    public getFIFOPeriod(): number {
+        return getFIFOPeriod(this.settings.fifoSampleRate);
+    }
+
+    public async begin(): Promise<void> {
+        await this._reset();
+
+        // Set up accelerometer
+        let dataToWrite: number = 0;
+        if (this._settings.accelEnabled) {
+            // Set up full scale and ODR
+            dataToWrite = XL_ODR_BYTE.get(this._settings.accelODR) | XL_FS_BYTE.get(this._settings.accelRange);
+            logger.info(`Accelerometer Settings: ${this._settings.accelRange} @ ${this._settings.accelODR}`);
+        }
+
+        // Write to the accelerometer config register
+        await this._writeByte(RegAddr.CTRL1_XL, dataToWrite);
+        logger.info(`Setting CTRL1_XL to 0x${dataToWrite.toString(16)}`);
+
+        // Set up Gyro
+        dataToWrite = 0;
+        if (this._settings.gyroEnabled) {
+            // Set up full scale and ODR
+            dataToWrite = G_ODR_BYTE.get(this._settings.gyroODR) | G_FS_BYTE.get(this._settings.gyroRange);
+            logger.info(`Gyro Settings: ${this._settings.gyroRange} @ ${this._settings.gyroODR}`);
+        }
+
+        // Write to the gyro config register
+        await this._writeByte(RegAddr.CTRL2_G, dataToWrite);
+        logger.info(`Setting CTRL2_G to 0x${dataToWrite.toString(16)}`);
+
+        await this._fifoBegin();
+    }
+
+    private async _fifoBegin(): Promise<void> {
+        const thresholdLByte = this._settings.fifoThreshold & 0xFF;
+        const thresholdHByte = (this._settings.fifoThreshold & 0x0F00) >> 8;
+
+        // Configure FIFO_CTRL3
+        let tempFIFO_CTRL3 = 0;
+        if (this._settings.gyroFIFOEnabled) {
+            tempFIFO_CTRL3 |= (this.settings.gyroFIFODecimation & 0x7) << 3;
+        }
+
+        if (this._settings.accelFIFOEnabled) {
+            tempFIFO_CTRL3 |= (this.settings.accelFIFODecimation & 0x7);
+        }
+
+        let tempFIFO_CTRL4 = 0;
+
+        // Configure FIFO_CTRL5
+        const tempFIFO_CTRL5 = FIFO_MODE_BYTE.get(this._settings.fifoModeSelection) | FIFO_ODR_BYTE.get(this._settings.fifoSampleRate);
+
+        await this._writeByte(RegAddr.FIFO_CTRL1, thresholdLByte);
+        logger.info(`Setting FIFO_CTRL1 to 0x${thresholdLByte.toString(16)}`);
+
+        await this._writeByte(RegAddr.FIFO_CTRL2, thresholdHByte);
+        logger.info(`Setting FIFO_CTRL2 to 0x${thresholdHByte.toString(16)}`);
+
+        await this._writeByte(RegAddr.FIFO_CTRL3, tempFIFO_CTRL3);
+        logger.info(`Setting FIFO_CTRL3 to 0x${tempFIFO_CTRL3.toString(16)}`);
+
+        await this._writeByte(RegAddr.FIFO_CTRL4, tempFIFO_CTRL4);
+        logger.info(`Setting FIFO_CTRL4 to 0x${tempFIFO_CTRL4.toString(16)}`);
+
+        await this._writeByte(RegAddr.FIFO_CTRL5, tempFIFO_CTRL5);
+        logger.info(`Setting FIFO_CTRL5 to 0x${tempFIFO_CTRL5.toString(16)}`);
+    }
+
     public async enableDefault(): Promise<void> {
         if (!this._isReady) {
             return;
         }
+
+        // Set up the device
+        await this._reset();
 
         // Accelerometer
         await this.setAccelerometerScale(AccelerometerScale.SCALE_2G);
@@ -214,7 +385,8 @@ export default class LSM6 {
         await this.setGyroScale(GyroScale.SCALE_1000_DPS);
 
         // Common
-        await this._writeByte(RegAddr.CTRL3_C, IF_INC_ENABLED);
+        const ctrl3cByte = CTRL3_C_OPTIONS.IF_INC;
+        await this._writeByte(RegAddr.CTRL3_C, ctrl3cByte);
     }
 
     public async setAccelerometerScale(scale: AccelerometerScale): Promise<void> {
@@ -222,11 +394,12 @@ export default class LSM6 {
             return;
         }
 
-        const controlByte = ACCEL_SCALE_CTRL_BYTE.get(scale);
-        await this._writeByte(RegAddr.CTRL1_XL, controlByte);
-        this._accelerometerScale = scale;
+        const controlByte = XL_ODR_BYTE.get(this.settings.accelODR) | XL_FS_BYTE.get(scale);
 
-        logger.info(`Accelerometer Scale: ${scale}`);
+        await this._writeByte(RegAddr.CTRL1_XL, controlByte);
+        this._settings.accelRange = scale;
+
+        logger.info(`Accelerometer Settings: ${scale} @ ${this.settings.accelODR}`);
     }
 
     public async setGyroScale(scale: GyroScale): Promise<void> {
@@ -234,109 +407,206 @@ export default class LSM6 {
             return;
         }
 
-        const controlByte = GYRO_SCALE_CTRL_BYTE.get(scale);
+        const controlByte = G_ODR_BYTE.get(this.settings.gyroODR) | G_FS_BYTE.get(scale);
+
         await this._writeByte(RegAddr.CTRL2_G, controlByte);
-        this._gyroScale = scale;
+        this._settings.gyroRange = scale;
 
-        logger.info(`Gyro Scale: ${scale}`);
+        logger.info(`Gyro Scale: ${scale} @ ${this.settings.gyroODR}`);
     }
 
-    /**
-     * Read the current accelerometer values and update our internal data
-     *
-     * The values obtained from the raw I2C read operations are the
-     * 16-bit twos-complement raw IMU values. They will need to be
-     * multiplied by the sensitivity values to obtain a reading in mG.
-     *
-     * The final values that get stored are in G
-     *
-     * Linear Acceleration Sensitivity: LA_So (page 15)
-     */
-    public async readAccelerometer(): Promise<void> {
-        if (!this._isReady) {
+    public fifoStart() {
+        if (this._fifoRunning) {
             return;
         }
 
-        const xla = await this._readByte(RegAddr.OUTX_L_XL);
-        const xha = await this._readByte(RegAddr.OUTX_H_XL);
-        const yla = await this._readByte(RegAddr.OUTY_L_XL);
-        const yha = await this._readByte(RegAddr.OUTY_H_XL);
-        const zla = await this._readByte(RegAddr.OUTZ_L_XL);
-        const zha = await this._readByte(RegAddr.OUTZ_H_XL);
+        logger.info("Starting FIFO reads");
+        this._fifoRunning = true;
 
-        const accelX = (xha << 8) | xla;
-        const accelY = (yha << 8) | yla;
-        const accelZ = (zha << 8) | zla;
-
-        const tmpBuf = Buffer.alloc(2);
-
-        tmpBuf.writeUInt16BE(accelX, 0);
-        const accelXsigned = tmpBuf.readInt16BE(0);
-
-        tmpBuf.writeUInt16BE(accelY, 0);
-        const accelYsigned = tmpBuf.readInt16BE(0);
-
-        tmpBuf.writeUInt16BE(accelZ, 0);
-        const accelZsigned = tmpBuf.readInt16BE(0);
-
-        const scaleFactor = ACCEL_OUTPUT_SCALE_FACTOR.get(this._accelerometerScale);
-
-        this._accel.x = (scaleFactor * accelXsigned) / 1000;
-        this._accel.y = (scaleFactor * accelYsigned) / 1000;
-        this._accel.z = (scaleFactor * accelZsigned) / 1000;
+        this._runFifoLoop();
     }
 
-    /**
-     * Read the current gyro values and update our internal data
-     *
-     * The values obtained from the raw I2C read operations are the
-     * 16-bit twos-complement raw IMU values. They will need to be
-     * multiplied by the sensitivity values to obtain a reading in mDPS.
-     *
-     * The final values that get stored are in degrees-per-second (dps)
-     *
-     * Angular Rate Sensitivity: G_So (page 15)
-     */
-    public async readGyro(): Promise<void> {
-        if (!this._isReady) {
+    public fifoStop() {
+        if (!this._fifoRunning) {
             return;
         }
 
-        const xlg = await this._readByte(RegAddr.OUTX_L_G);
-        const xhg = await this._readByte(RegAddr.OUTX_H_G);
-        const ylg = await this._readByte(RegAddr.OUTY_L_G);
-        const yhg = await this._readByte(RegAddr.OUTY_H_G);
-        const zlg = await this._readByte(RegAddr.OUTZ_L_G);
-        const zhg = await this._readByte(RegAddr.OUTZ_H_G);
-
-        const gyroX = (xhg << 8) | xlg;
-        const gyroY = (yhg << 8) | ylg;
-        const gyroZ = (zhg << 8) | zlg;
-
-        const tmpBuf = Buffer.alloc(2);
-
-        tmpBuf.writeUInt16BE(gyroX, 0);
-        const gyroXsigned = tmpBuf.readInt16BE(0);
-
-        tmpBuf.writeUInt16BE(gyroY, 0);
-        const gyroYsigned = tmpBuf.readInt16BE(0);
-
-        tmpBuf.writeUInt16BE(gyroZ, 0);
-        const gyroZsigned = tmpBuf.readInt16BE(0);
-
-        const scaleFactor = GYRO_OUTPUT_SCALE_FACTOR.get(this._gyroScale);
-
-        this._gyro.x = ((scaleFactor * gyroXsigned) / 1000) - this._gyroOffset.x;
-        this._gyro.y = ((scaleFactor * gyroYsigned) / 1000) - this._gyroOffset.y;
-        this._gyro.z = ((scaleFactor * gyroZsigned) / 1000) - this._gyroOffset.z;
+        logger.info("Stopping FIFO reads");
+        this._fifoRunning = false;
     }
 
-    private _readByte(cmd: number): Promise<number> {
+    /**
+     * Returns any unprocessed FIFO Frames and clears the internal buffer
+     */
+    public getNewFIFOData(): FIFOFrame[] {
+        const ret: FIFOFrame[] = [...this._fifoBuffer];
+        this._fifoBuffer = [];
+        return ret;
+    }
+
+    private async _reset(): Promise<void> {
+        // Initiate a software reboot
+
+        // Set the gyro in power down mode
+        await this._writeByte(RegAddr.CTRL2_G, 0x00);
+
+        // Set accelerometer in high perf
+        await this._writeByte(RegAddr.CTRL6_C, 0x00);
+
+        // Send the SW_RESET signal
+        await this._writeByte(RegAddr.CTRL3_C, CTRL3_C_OPTIONS.SW_RESET);
+
+        for (let i = 0; i < 10; i++) {
+            if (i > 0) {
+                logger.info(`Waiting for reset... ${i}ms`);
+            }
+            await this._waitMS(1);
+            const val = await this._readByte(RegAddr.CTRL3_C);
+            if ((val & 0x1) === 0) {
+                logger.info("Reset complete");
+                return;
+            }
+        }
+
+        logger.error("Reset timed out...");
+        return;
+    }
+
+    /**
+     * Perform a read of the FIFO buffer and store any saved frames into our
+     * internal storage.
+     *
+     * A "frame" consists of a snapshot of gyro and accelerometer values. The
+     * time between each "frame" is dependent on the FIFO ODR value
+     * @private
+     */
+    private async _fifoLoop(): Promise<void> {
+        const start = Date.now();
+        const status = await this._fifoGetStatus();
+        logger.silly(`FIFO Status: 0x${status.toString(16)}`);
+
+        const numUnread = status & 0xFFF;
+        logger.silly(`Num unread entries: ${numUnread}`);
+        const valBuf = Buffer.alloc(2);
+
+        const tempFrame: FIFOFrame = {
+            gyroX: 0,
+            gyroY: 0,
+            gyroZ: 0,
+            accelX: 0,
+            accelY: 0,
+            accelZ: 0
+        }
+
+        const accelScaleFactor = ACCEL_OUTPUT_SCALE_FACTOR.get(this._settings.accelRange);
+        const gyroScaleFactor = GYRO_OUTPUT_SCALE_FACTOR.get(this._settings.gyroRange);
+
+        // We only want to process groups of 6 values (which correspond to 3 gyro + 3 accel values)
+        // An IMU "data frame" consists of 6 reads off the FIFO register
+        // The order of values read are: GyroX, GyroY, GyroZ, AccelX, AccelY, AccelZ
+        //
+        // All values read from the FIFO are read in as 16-bit twos-complement raw values.
+        // These need to be multiplied by the sensitivity values to obtain a reading in
+        // mG (for the accelerometer) or mDPS (for the gyro). Frame data is stored with
+        // the following units:
+        // G for accelerometer values
+        // DPS for gyro values
+        //
+        // References
+        // Angular Rate Sensitivity: G_So (page 15)
+        // Linear Acceleration Sensitivity: LA_So (page 15)
+        const shouldProcess = (numUnread % 6 === 0);
+        for (let i = 0; i < numUnread; i++) {
+            // ReadWord is implemented as a Little Endian 2 byte read
+            // The register layout (in increasing memory address order) is
+            // FIFO_DATA_OUT_L, FIFO_DATA_OUT_H
+            // We now read the 2 bytes starting at FIFO_DATA_OUT_L as an
+            // unsigned 16 bit number, and convert that to a signed 16 bit
+            let val = await this._readWord(RegAddr.FIFO_DATA_OUT_L);
+            valBuf.writeUInt16LE(val);
+            val = valBuf.readInt16LE();
+
+            if (shouldProcess) {
+                switch (i % 6) {
+                    case 0:
+                        tempFrame.gyroX = ((val * gyroScaleFactor) / 1000) - this._gyroOffset.x;
+                        break;
+                    case 1:
+                        tempFrame.gyroY = ((val * gyroScaleFactor) / 1000) - this._gyroOffset.y;
+                        break;
+                    case 2:
+                        tempFrame.gyroZ = ((val * gyroScaleFactor) / 1000) - this._gyroOffset.z;
+                        break;
+                    case 3:
+                        tempFrame.accelX = (val * accelScaleFactor) / 1000;
+                        break;
+                    case 4:
+                        tempFrame.accelY = (val * accelScaleFactor) / 1000;
+                        break;
+                    case 5:
+                        tempFrame.accelZ = (val * accelScaleFactor) / 1000;
+                        this._fifoBuffer.push({...tempFrame});
+                        break;
+                }
+            }
+        }
+
+        const end = Date.now();
+        logger.silly(`FIFO LOOP took ${end-start}ms. Local Buffer size ${this._fifoBuffer.length}`);
+    }
+
+    /**
+     * Read the FIFO status byte
+     */
+    private async _fifoGetStatus(): Promise<number> {
+        let temp = 0;
+        let accum = 0;
+
+        temp = await this._readByte(RegAddr.FIFO_STATUS1);
+        accum = temp;
+        temp = await this._readByte(RegAddr.FIFO_STATUS2);
+        accum |= (temp << 8);
+
+        return accum;
+    }
+
+    /**
+     * Wrapper function for constantly checking the FIFO buffer
+     */
+    private _runFifoLoop() {
+        setImmediate(async () => {
+            await this._fifoLoop();
+            if (this._fifoRunning) {
+                this._runFifoLoop();
+            }
+        });
+    }
+
+    private async _readByte(cmd: number): Promise<number> {
         return this._i2cBus.readByte(this._i2cAddress, cmd);
     }
 
-    private _writeByte(cmd: number, byte: number): Promise<void> {
+    private async _writeByte(cmd: number, byte: number): Promise<void> {
         return this._i2cBus.writeByte(this._i2cAddress, cmd, byte);
     }
 
+    private async _readWord(cmd: number): Promise<number> {
+        return this._i2cBus.readWord(this._i2cAddress, cmd);
+    }
+
+    private async _sendByte(cmd: number): Promise<void> {
+        return this._i2cBus.sendByte(this._i2cAddress, cmd);
+    }
+
+    private async _receiveByte(): Promise<number> {
+        return this._i2cBus.receiveByte(this._i2cAddress);
+    }
+
+    private async _waitMS(delayMS: number): Promise<void> {
+        return new Promise(resolve => {
+            setTimeout(() => {
+                resolve();
+            }, delayMS);
+        });
+    }
 }

--- a/src/robot/romi-accelerometer.ts
+++ b/src/robot/romi-accelerometer.ts
@@ -1,5 +1,6 @@
 import { RobotAccelerometer } from "@wpilib/wpilib-ws-robot";
-import LSM6, { AccelerometerScale } from "./devices/core/lsm6/lsm6";
+import LSM6, { FIFOFrame } from "./devices/core/lsm6/lsm6";
+import { AccelerometerScale } from "./devices/core/lsm6/lsm6-settings";
 
 export default class RomiAccelerometer extends RobotAccelerometer {
     private _sensitivity: AccelerometerScale;
@@ -31,10 +32,17 @@ export default class RomiAccelerometer extends RobotAccelerometer {
         this._lsm6.setAccelerometerScale(this._sensitivity);
     }
 
-    public update(): void {
+    public updateFromFrames(buffer: FIFOFrame[], dt: number): void {
+        if (buffer.length === 0) {
+            return;
+        }
+
+        // Update to the latest frame's data
+        const frame = buffer[buffer.length - 1];
+
         // These follow NED conventions
-        this.accelX = -this._lsm6.accelerationG.x;
-        this.accelY = this._lsm6.accelerationG.y;
-        this.accelZ = this._lsm6.accelerationG.z;
+        this.accelX = -frame.accelX;
+        this.accelY = frame.accelY;
+        this.accelZ = frame.accelZ;
     }
 }


### PR DESCRIPTION
This PR switches over to using the LSM6 FIFO feature (instead of reading on an interval). This (should) allow for better angle measurements due to a known time period between values.

Theory of Operation:
- The robot object sets up the IMU with the appropriate data rates and kicks off FIFO mode
- The IMU continually polls the FIFO status byte, reads off the FIFO and populates an internal "IMU Frame" buffer with the read values
- Data is buffered in the IMU object until read externally

This allows the (slower) I2C reading mechanism to be run as quickly as possible, while the (faster) processing mechanism can poll at it's own rate, but still have accurate measurements.

With this change, performing a calibration on the IMU will temporarily pause readings on the robot side.