### PR TITLE
feature: Add custom device support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -925,9 +925,9 @@
       "dev": true
     },
     "@wpilib/node-wpilib-ws": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@wpilib/node-wpilib-ws/-/node-wpilib-ws-0.1.1.tgz",
-      "integrity": "sha512-qwhEhJD2Gj7RjqDOoyEClcwE94SA+era1ljoQ/L1P7WK8UYQy2sfjx6MSM2d0sFPCXeELSNUmgTqVd711ni61A==",
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@wpilib/node-wpilib-ws/-/node-wpilib-ws-0.1.3.tgz",
+      "integrity": "sha512-LieSxFVvFJIek06FSQmioy8aXm4xoncaXsLYG1mKio1OVjMVfv5IvDLMMb0lql1vjmas0q2x1PNQAWnKP36p8w==",
       "requires": {
         "ip-address": "^7.1.0",
         "strict-event-emitter-types": "^2.0.0",
@@ -935,11 +935,11 @@
       }
     },
     "@wpilib/wpilib-ws-robot": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@wpilib/wpilib-ws-robot/-/wpilib-ws-robot-1.1.0.tgz",
-      "integrity": "sha512-k0Nbke2JVVLiE1lYbkmQsrC5qJ1kT+09rXzKmIMtLHMcoyVO1VHG6Nx4g1sfDBJAbRiYJy5lL/CADxJIb37USA==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@wpilib/wpilib-ws-robot/-/wpilib-ws-robot-1.2.1.tgz",
+      "integrity": "sha512-cU++W5TYPKVWq2b7tD6suLY9hVNEPnjWc85qVPu1ZuV4ptZTDLPR3l+DpMKZHKvOAhwvf35BKoP/E8kHyoYW7Q==",
       "requires": {
-        "@wpilib/node-wpilib-ws": "0.1.1"
+        "@wpilib/node-wpilib-ws": "0.1.3"
       }
     },
     "abab": {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   },
   "homepage": "https://github.com/wpilibsuite/wpilib-ws-robot-romi#readme",
   "dependencies": {
-    "@wpilib/wpilib-ws-robot": "1.1.0",
+    "@wpilib/wpilib-ws-robot": "1.2.1",
     "commander": "^6.1.0",
     "cors": "^2.8.5",
     "express": "^4.17.1",

--- a/sample-config.json
+++ b/sample-config.json
@@ -1,0 +1,9 @@
+{
+    "ioConfig": ["dio", "pwm", "dio", "ain", "ain"],
+    "customDevices": [
+        {
+            "type": "rev-color-sensor",
+            "config": {}
+        }
+    ]
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -214,6 +214,10 @@ restInterface.addStatusQuery("battery-status", () => {
     };
 });
 
+restInterface.addStatusQuery("robot-io-channel-info", () => {
+    return robot.ioChannelInfo;
+});
+
 restInterface.addIMUAction("calibrate", () => {
     gyroCalibrationUtil.calibrate();
 });

--- a/src/robot/devices/custom/custom-device.ts
+++ b/src/robot/devices/custom/custom-device.ts
@@ -1,0 +1,75 @@
+import { DigitalChannelMode, SimDevice } from "@wpilib/wpilib-ws-robot";
+import { NetworkTable, NetworkTableInstance } from "node-ntcore";
+import QueuedI2CBus from "../../../device-interfaces/i2c/queued-i2c-bus";
+
+export interface IOInterfaces {
+    numDioPorts?: number;
+    numAnalogInPorts?: number;
+    numPwmOutPorts?: number;
+    simDevices?: SimDevice[];
+}
+
+export interface RobotHardwareInterfaces {
+    i2cBus: QueuedI2CBus
+}
+
+export default abstract class CustomDevice {
+    private _deviceType: string;
+    private _isSingleton: boolean;
+
+    private _deviceNetworkTable: NetworkTable | null = null;
+
+    protected _robotHWInterfaces: RobotHardwareInterfaces;
+
+    constructor(deviceType: string, isSingleton: boolean, robotHW: RobotHardwareInterfaces, useNT: boolean = false) {
+        this._deviceType = deviceType;
+        this._isSingleton = isSingleton;
+        this._robotHWInterfaces = robotHW;
+
+        if (useNT) {
+            this._deviceNetworkTable = NetworkTableInstance.getDefault().getTable(`/Romi/CustomDevice/${this.identifier}`);
+        }
+    }
+
+    public get deviceType(): string {
+        return this._deviceType;
+    }
+
+    public get isSingleton(): boolean {
+        return this._isSingleton;
+    }
+
+    public get identifier(): string {
+        return this._deviceType;
+    }
+
+    public abstract get ioInterfaces(): IOInterfaces;
+
+    protected get networkTable(): NetworkTable | null {
+        return this._deviceNetworkTable;
+    }
+
+    public abstract update(): void;
+
+    // IO operations
+    public setDigitalChannelMode(channel: number, mode: DigitalChannelMode): void {
+        throw new Error("setDigitalChannelMode must be implemented by subclass");
+    }
+
+    public setDIOValue(channel: number, value: boolean): void {
+        throw new Error("setDIOValue must be implemented by subclass");
+    }
+
+    public setPWMValue(channel: number, value: number): void {
+        throw new Error("setPWMValue must be implemented by subclass");
+    }
+
+    public getAnalogInVoltage(channel: number): Promise<number> {
+        throw new Error("getAnalogInValue must be implemented by subclass");
+    }
+
+    public getDigitalInValue(channel: number): Promise<boolean> {
+        throw new Error("getDigitalInValue must be implemented by subclass");
+    }
+
+}

--- a/src/robot/devices/custom/device-library.ts
+++ b/src/robot/devices/custom/device-library.ts
@@ -1,0 +1,25 @@
+import CustomDevice, { RobotHardwareInterfaces } from "./custom-device";
+import ExampleCustomDevice from "./example-custom-device";
+import RevColorSensorV3 from "./rev-color-sensor-v3";
+
+export interface CustomDeviceConstructor {
+    new (robotHardware: RobotHardwareInterfaces, config: any): CustomDevice;
+}
+
+const CUSTOM_DEVICE_LIST: Map<string, CustomDeviceConstructor> = new Map<string, CustomDeviceConstructor>();
+
+// Add new devices to the map
+CUSTOM_DEVICE_LIST.set("example-custom-device", ExampleCustomDevice);
+CUSTOM_DEVICE_LIST.set("rev-color-sensor", RevColorSensorV3);
+
+export default class CustomDeviceFactory {
+    public static createDevice(type: string, robotHardware: RobotHardwareInterfaces, config: any): CustomDevice {
+        const ctor = CUSTOM_DEVICE_LIST.get(type);
+
+        if (!ctor) {
+            throw new Error(`Invalid Custom Device Type (${type})`);
+        }
+
+        return new ctor(robotHardware, config);
+    }
+}

--- a/src/robot/devices/custom/example-custom-device/index.ts
+++ b/src/robot/devices/custom/example-custom-device/index.ts
@@ -1,0 +1,128 @@
+import { DigitalChannelMode } from "@wpilib/wpilib-ws-robot";
+import LogUtil from "../../../../utils/logging/log-util";
+import CustomDevice, { IOInterfaces, RobotHardwareInterfaces } from "../custom-device";
+
+export enum ExampleDevicePortModes {
+    DIO = "DIO",
+    ANALOG_IN = "ANALOG_IN",
+    PWM = "PWM"
+}
+
+export interface ExampleDeviceConfig {
+    portConfigs: ExampleDevicePortModes[];
+}
+
+const logger = LogUtil.getLogger("EXAMPLE-DEVICE");
+
+export default class ExampleCustomDevice extends CustomDevice {
+    private _config: ExampleDeviceConfig;
+
+    private _numDIO: number = 0;
+    private _numAnalogIn: number = 0;
+    private _numPWM: number = 0;
+
+    private _dioChannels: number[] = [];
+    private _ainChannels: number[] = [];
+    private _pwmChannels: number[] = [];
+
+    private _dioValue: boolean = false;
+    private _ainValue: number = 0;
+    private _ainDelta: number = 0.2;
+    private _lastUpdateTimeMs: number = 0;
+
+    constructor(robotHW: RobotHardwareInterfaces, config: ExampleDeviceConfig) {
+        super("ExampleDevice", false, robotHW);
+
+        this._config = config;
+        this._setup();
+    }
+
+    public get ioInterfaces(): IOInterfaces {
+
+        return {
+            numDioPorts: this._numDIO,
+            numAnalogInPorts: this._numAnalogIn,
+            numPwmOutPorts: this._numPWM
+        };
+    }
+
+    public update(): void {
+        if (this._lastUpdateTimeMs === 0) {
+            this._lastUpdateTimeMs = Date.now();
+            return;
+        }
+
+        if (Date.now() - this._lastUpdateTimeMs > 500) {
+            this._dioValue = !this._dioValue;
+
+            // Triangular Wave
+            this._ainValue += this._ainDelta;
+            if (this._ainValue > 5) {
+                this._ainValue -= this._ainDelta;
+                this._ainDelta = -this._ainDelta;
+            }
+            else if (this._ainValue < 0) {
+                this._ainValue -= this._ainDelta;
+                this._ainDelta = -this._ainDelta;
+            }
+            this._lastUpdateTimeMs = Date.now();
+        }
+    }
+
+    private _setup() {
+        if (this._config.portConfigs.length !== 5) {
+            throw new Error(`Invalid number of port configs specified. Expected 5 but got ${this._config.portConfigs.length}`);
+        }
+
+        // In this example, all we do is increment the counts of the
+        // various port types
+        this._config.portConfigs.forEach((portConfig, idx) => {
+            switch (portConfig) {
+                case ExampleDevicePortModes.DIO:
+                    this._numDIO++;
+                    this._dioChannels.push(idx);
+                    break;
+                case ExampleDevicePortModes.ANALOG_IN:
+                    this._numAnalogIn++;
+                    this._ainChannels.push(idx);
+                    break;
+                case ExampleDevicePortModes.PWM:
+                    this._numPWM++;
+                    this._pwmChannels.push(idx);
+                    break;
+            }
+        });
+    }
+
+    public setDigitalChannelMode(channel: number, mode: DigitalChannelMode): void {
+        if (this._dioChannels[channel] === undefined) {
+            return;
+        }
+
+        logger.info(`Setting DIO port ${channel} (Physical pin ${this._dioChannels[channel]}) mode to ${mode}`);
+    }
+
+    public setDIOValue(channel: number, value: boolean): void {
+        if (this._dioChannels[channel] === undefined) {
+            return;
+        }
+
+        logger.info(`Setting DIO port ${channel} (Physical pin ${this._dioChannels[channel]}) value to ${value}`);
+    }
+
+    public setPWMValue(channel: number, value: number): void {
+        if (this._pwmChannels[channel] === undefined) {
+            return;
+        }
+
+        logger.info(`Setting PWM port ${channel} (Physical pin ${this._pwmChannels[channel]}) value to ${value}`);
+    }
+
+    public getAnalogInVoltage(channel: number): Promise<number> {
+        return Promise.resolve(this._ainValue);
+    }
+
+    public getDigitalInValue(channel: number): Promise<boolean> {
+        return Promise.resolve(this._dioValue);
+    }
+}

--- a/src/robot/devices/custom/rev-color-sensor-v3/index.ts
+++ b/src/robot/devices/custom/rev-color-sensor-v3/index.ts
@@ -1,0 +1,301 @@
+import { NetworkTableEntry } from "node-ntcore";
+import I2CPromisifiedBus from "../../../../device-interfaces/i2c/i2c-connection";
+import LogUtil from "../../../../utils/logging/log-util";
+import CustomDevice, { IOInterfaces, RobotHardwareInterfaces } from "../custom-device";
+import SimColorSensor from "./sim-color-sensor";
+
+/**
+ * Implementation Note
+ *
+ * This implementation copies a lot from REV's Java API
+ * https://github.com/REVrobotics/Color-Sensor-v3/blob/master/src/main/java/com/revrobotics/ColorSensorV3.java
+ *
+ * Specifically around the I2C reads.
+ *
+ * It is currently not 100% feature complete (we don't allow configuration changes
+ * just yet) but works decently well as is.
+ */
+
+const DEVICE_IDENT: string = "REV-ColorSensorV3";
+
+const I2C_ADDRESS = 0x52;
+const PART_IDENT = 0xC2;
+
+enum Register {
+    MAIN_CTRL = 0x00,
+    PROX_SENSOR_LED = 0x01,
+    PROX_SENSOR_PULSES = 0x02,
+    PROX_SENSOR_RATE = 0x03,
+    LIGHT_SENSOR_MEAUSUREMENT_RATE = 0x04,
+    LIGHT_SENSOR_GAIN = 0x05,
+    PART_ID = 0x06,
+    MAIN_STATUS = 0x07,
+    PROX_DATA = 0x08,
+    DATA_INFRARED = 0x0A,
+    DATA_GREEN = 0x0D,
+    DATA_BLUE = 0x10,
+    DATA_RED = 0x13
+}
+
+enum MainControl {
+    RGB_MODE = 0x04, // If bit is set to 1, color channels are activated
+    LIGHT_SENSOR_ENABLE = 0x02,
+    PROX_SENSOR_ENABLE = 0x01,
+    OFF = 0x00
+}
+
+enum GainFactor {
+    GAIN_1X = 0x00,
+    GAIN_3X = 0x01,
+    GAIN_6X = 0x02,
+    GAIN_9X = 0x03,
+    GAIN_18X = 0x04
+}
+
+enum LEDCurrent {
+    PULSE_2mA = 0x00,
+    PULSE_5mA = 0x01,
+    PULSE_10mA = 0x02,
+    PULSE_25mA = 0x03,
+    PULSE_50mA = 0x04,
+    PULSE_75mA = 0x05,
+    PULSE_100mA = 0x06, // default value
+    PULSE_125mA = 0x07
+}
+
+enum LEDPulseFrequency {
+    FREQ_60kHZ = 0x18, // default value
+    FREQ_70kHZ = 0x40,
+    FREQ_80kHZ = 0x28,
+    FREQ_90kHZ = 0x30,
+    FREQ_100kHAZ = 0x38
+}
+
+enum ProximitySensorResolution {
+    PROX_RES_8BIT = 0x00,
+    PROX_RES_9BIT = 0x08,
+    PROX_RES_10BIT = 0x10,
+    PROX_RES_11BIT = 0x18
+}
+
+enum ProximitySensorMeasurementRate {
+    PROX_RATE_6MS = 0x01,
+    PROX_RATE_12MS = 0x02,
+    PROX_RATE_25MS = 0x03,
+    PROX_RATE_50MS = 0x04,
+    PROX_RATE_100MS = 0x05, // default value
+    PROX_RATE_200MS = 0x06,
+    PROX_RATE_400MS = 0x07
+}
+
+enum ColorSensorResolution {
+    COLOR_SENSOR_RES_20BIT = 0x00,
+    COLOR_SENSOR_RES_19BIT = 0x10,
+    COLOR_SENSOR_RES_18BIT = 0x20,
+    COLOR_SENSOR_RES_17BIT = 0x30,
+    COLOR_SENSOR_RES_16BIT = 0x40,
+    COLOR_SENSOR_RES_13BIT = 0x50
+}
+
+enum ColorSensorMeasurementRate {
+    COLOR_RATE_25MS = 0,
+    COLOR_RATE_50MS = 1,
+    COLOR_RATE_100MS = 2,
+    COLOR_RATE_200MS = 3,
+    COLOR_RATE_500MS = 4,
+    COLOR_RATE_1000MS = 5,
+    COLOR_RATE_2000MS = 7
+}
+
+const logger = LogUtil.getLogger(DEVICE_IDENT);
+
+export interface RevColorSensorConfig {
+    port?: number;
+    channel?: number;
+}
+
+export default class RevColorSensorV3 extends CustomDevice {
+    private _config: RevColorSensorConfig;
+    private _i2cBus: I2CPromisifiedBus;
+
+    private _lastRed: number = 0;
+    private _lastBlue: number = 0;
+    private _lastGreen: number = 0;
+    private _lastIR: number = 0;
+
+    private _lastProx: number = 0;
+
+    private _simDevice: SimColorSensor;
+
+    private _ntEntryRed: NetworkTableEntry;
+    private _ntEntryGreen: NetworkTableEntry;
+    private _ntEntryBlue: NetworkTableEntry;
+    private _ntEntryIR: NetworkTableEntry;
+    private _ntEntryProx: NetworkTableEntry;
+
+    constructor(robotHW: RobotHardwareInterfaces, config: RevColorSensorConfig) {
+        super(DEVICE_IDENT, true, robotHW, true);
+
+        this._config = config;
+        this._i2cBus = robotHW.i2cBus.rawBus;
+
+        // Set up NT entries
+        if (this.networkTable) {
+            this._ntEntryRed = this.networkTable.getEntry("Red");
+            this._ntEntryGreen = this.networkTable.getEntry("Green");
+            this._ntEntryBlue = this.networkTable.getEntry("Blue");
+            this._ntEntryIR = this.networkTable.getEntry("IR");
+            this._ntEntryProx = this.networkTable.getEntry("Proximity");
+        }
+
+        const devicePortIndex: number = config.port !== undefined ? config.port : 0;
+        const deviceChannelIndex: number = config.channel !== undefined ? config.channel : I2C_ADDRESS;
+
+        this._simDevice = new SimColorSensor(devicePortIndex, deviceChannelIndex);
+
+        this._checkDeviceID()
+        .then(idValid => {
+            if (idValid) {
+                return this._initializeDevice()
+                .then(() => {
+                    return this.hasReset();
+                });
+            }
+        });
+    }
+
+    public get ioInterfaces(): IOInterfaces {
+        // Returning an empty object since this uses SimDevice + NT
+        return {
+            simDevices: [this._simDevice]
+        };
+    }
+
+    public async update(): Promise<void> {
+        this._lastRed = await this._read20BitRegister(Register.DATA_RED);
+        this._lastGreen = await this._read20BitRegister(Register.DATA_GREEN);
+        this._lastBlue = await this._read20BitRegister(Register.DATA_BLUE);
+        this._lastIR = await this._read20BitRegister(Register.DATA_INFRARED);
+
+        this._lastProx = await this._read11BitRegister(Register.PROX_DATA);
+
+        // Update the SimDevice
+        this._simDevice.red = this._lastRed;
+        this._simDevice.green = this._lastGreen;
+        this._simDevice.blue = this._lastBlue;
+        this._simDevice.infrared = this._lastIR;
+        this._simDevice.proximity = this._lastProx;
+
+        // Also update the NT Interface
+        if (this.networkTable) {
+            this._ntEntryRed.setDouble(this._lastRed);
+            this._ntEntryGreen.setDouble(this._lastGreen);
+            this._ntEntryBlue.setDouble(this._lastBlue);
+            this._ntEntryIR.setDouble(this._lastIR);
+            this._ntEntryProx.setDouble(this._lastProx);
+        }
+    }
+
+    /**
+     * Configure the IR LED used by proximity sensor
+     * @param freq
+     * @param current
+     * @param pulses
+     */
+    public async configureProximitySensorLED(freq: LEDPulseFrequency, current: LEDCurrent, pulses: number): Promise<void> {
+        const buf = Buffer.alloc(1);
+        buf.writeUInt8(pulses);
+        await this._writeByte(Register.PROX_SENSOR_LED, freq | current);
+        await this._writeByte(Register.PROX_SENSOR_PULSES, buf.readUInt8());
+    }
+
+    /**
+     * Configure the proximity sensor
+     * @param res
+     * @param rate
+     */
+    public async configureProximitySensor(res: ProximitySensorResolution, rate: ProximitySensorMeasurementRate): Promise<void> {
+        await this._writeByte(Register.PROX_SENSOR_RATE, res | rate);
+    }
+
+    public async configureColorSensor(res: ColorSensorResolution, rate: ColorSensorMeasurementRate, gain: GainFactor): Promise<void> {
+        await this._writeByte(Register.LIGHT_SENSOR_MEAUSUREMENT_RATE, res | rate);
+        await this._writeByte(Register.LIGHT_SENSOR_GAIN, gain);
+    }
+
+    public getProximity(): number {
+        return this._lastProx;
+    }
+
+    public getRed(): number {
+        return this._lastRed;
+    }
+
+    public getGreen(): number {
+        return this._lastGreen;
+    }
+
+    public getBlue(): number {
+        return this._lastBlue;
+    }
+
+    public getIR(): number {
+        return this._lastIR;
+    }
+
+    public async hasReset(): Promise<boolean> {
+        const value = await this._readByte(Register.MAIN_STATUS);
+        return (value & 0x20) !== 0;
+    }
+
+    private async _checkDeviceID(): Promise<boolean> {
+        try {
+            const value = await this._readByte(Register.PART_ID);
+            if (value !== PART_IDENT) {
+                logger.error("Unknown device found with same I2C address, but incorrect ident");
+                return false;
+            }
+
+            return true;
+        }
+        catch (err) {
+            logger.error("Could not find REV Color Sensor");
+            return false;
+        }
+    }
+
+    private async _initializeDevice(): Promise<void> {
+        await this._writeByte(Register.MAIN_CTRL, MainControl.RGB_MODE | MainControl.LIGHT_SENSOR_ENABLE | MainControl.PROX_SENSOR_ENABLE);
+        await this._writeByte(Register.PROX_SENSOR_RATE, ProximitySensorResolution.PROX_RES_11BIT | ProximitySensorMeasurementRate.PROX_RATE_100MS);
+        await this._writeByte(Register.PROX_SENSOR_PULSES, 32);
+    }
+
+    private async _read11BitRegister(reg: Register): Promise<number> {
+        const buf = Buffer.alloc(2);
+        const offset = (reg as number);
+
+        buf[0] = await this._readByte(offset);
+        buf[1] = await this._readByte(offset + 1);
+
+        return buf.readUInt16LE() & 0x7FF;
+    }
+
+    private async _read20BitRegister(reg: Register): Promise<number> {
+        const buf = Buffer.alloc(4);
+        const offset = (reg as number);
+
+        buf[0] = await this._readByte(offset);
+        buf[1] = await this._readByte(offset + 1);
+        buf[2] = await this._readByte(offset + 2);
+
+        return buf.readUInt32LE() & 0x03FFFF;
+    }
+
+    private async _writeByte(cmd: number, byte: number): Promise<void> {
+        return this._i2cBus.writeByte(I2C_ADDRESS, cmd, byte);
+    }
+
+    private async _readByte(cmd: number): Promise<number> {
+        return this._i2cBus.readByte(I2C_ADDRESS, cmd);
+    }
+}

--- a/src/robot/devices/custom/rev-color-sensor-v3/sim-color-sensor.ts
+++ b/src/robot/devices/custom/rev-color-sensor-v3/sim-color-sensor.ts
@@ -1,0 +1,53 @@
+import { SimDevice, FieldDirection } from "@wpilib/wpilib-ws-robot";
+
+export default class SimColorSensor extends SimDevice {
+    constructor(portIdx: number, chIdx: number) {
+        super("REV Color Sensor V3", portIdx, chIdx);
+
+        this.registerField("Red", FieldDirection.INPUT_TO_ROBOT_CODE, 0.0);
+        this.registerField("Green", FieldDirection.INPUT_TO_ROBOT_CODE, 0.0);
+        this.registerField("Blue", FieldDirection.INPUT_TO_ROBOT_CODE, 0.0);
+        this.registerField("IR", FieldDirection.INPUT_TO_ROBOT_CODE, 0.0);
+        this.registerField("Proximity", FieldDirection.INPUT_TO_ROBOT_CODE, 0.0);
+    }
+
+    public set red(value: number) {
+        this.setValue("Red", value);
+    }
+
+    public get red(): number {
+        return this.getValue("Red");
+    }
+
+    public set green(value: number) {
+        this.setValue("Green", value);
+    }
+
+    public get green(): number {
+        return this.getValue("Green");
+    }
+
+    public set blue(value: number) {
+        this.setValue("Blue", value);
+    }
+
+    public get blue(): number {
+        return this.getValue("Blue");
+    }
+
+    public set infrared(value: number) {
+        this.setValue("IR", value);
+    }
+
+    public get infrared(): number {
+        return this.getValue("IR");
+    }
+
+    public set proximity(value: number) {
+        this.setValue("Proximity", value);
+    }
+
+    public get proximity(): number {
+        return this.getValue("Proximity");
+    }
+}

--- a/src/robot/romi-config.ts
+++ b/src/robot/romi-config.ts
@@ -3,10 +3,16 @@ import jsonfile from "jsonfile";
 import ProgramArguments from "../program-arguments";
 import { Vector3 } from "./devices/core/lsm6/lsm6";
 
+export interface CustomDeviceSpec {
+    type: string;
+    config?: any;
+}
+
 export interface RomiConfigJson {
     ioConfig: string[];
     gyroZeroOffset: Vector3;
     gyroFilterWindowSize?: number;
+    customDevices?: CustomDeviceSpec[];
 }
 
 export enum IOPinMode {
@@ -36,6 +42,7 @@ export default class RomiConfiguration {
     private _gyroZeroOffset: Vector3 = { x: 0, y: 0, z: 0};
 
     private _gyroFilterWindowSize: number = 5;
+    private _customDevices: CustomDeviceSpec[] = [];
 
     constructor(programArgs?: ProgramArguments) {
         // Pre-load the external IO configuration
@@ -92,6 +99,10 @@ export default class RomiConfiguration {
                     if (romiConfig.gyroFilterWindowSize) {
                         this._gyroFilterWindowSize = romiConfig.gyroFilterWindowSize;
                     }
+
+                    if (romiConfig.customDevices) {
+                        this._customDevices = romiConfig.customDevices;
+                    }
                 }
                 else {
                     isConfigError = true;
@@ -138,5 +149,13 @@ export default class RomiConfiguration {
             return `EXT${idx}(${val.mode})`;
         })
         .join(", ");
+    }
+
+    public set customDevices(val: CustomDeviceSpec[]) {
+        this._customDevices = val;
+    }
+
+    public get customDevices(): CustomDeviceSpec[] {
+        return this._customDevices;
     }
 }


### PR DESCRIPTION
This PR adds support for custom devices. These are devices that (for now) are connected over I2C, and can expose themselves to robot code as DIO ports, Analog In ports, PWM Out ports, SimDevice-s or even just broadcast values over NetworkTables.

Two examples are provided in this PR:
- An example custom device which exposes a configurable number of DIO/AnalogIn/PWM ports
- An interface to the REV Color Sensor V3, which provides color data both over the SimDevice interface (which allows you to use this with the REV vendordep in robot code), and over NT