### PR TITLE
Updating to node-ntcore 0.1.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3778,9 +3778,9 @@
       }
     },
     "node-ntcore": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/node-ntcore/-/node-ntcore-0.1.5.tgz",
-      "integrity": "sha512-76Qnba0rePNAJfs3BFO+my4Bno6ayB8Q7ElYYLehRj2Y4DbbrIYStO1Y9UpV7RAv7Mu05ur7FXEEUcfk8jq5aA==",
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/node-ntcore/-/node-ntcore-0.1.7.tgz",
+      "integrity": "sha512-5T81ydbapoOaMCOJOL333G97qjM+xv0l4uOLqzyRppDY6rZ81hTUrhKKM8EpXukSWSo40PGjOj7my5z+h9GvkA==",
       "requires": {
         "fast-deep-equal": "^3.1.3",
         "ieee754": "^1.2.1",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "express": "^4.17.1",
     "ip-address": "^7.1.0",
     "jsonfile": "^6.0.1",
-    "node-ntcore": "^0.1.5",
+    "node-ntcore": "^0.1.7",
     "promise-queue": "^2.2.5",
     "winston": "^3.3.3"
   },


### PR DESCRIPTION
Fixes crash on NT 3.0 datatype changes